### PR TITLE
Fire moveend event on synced map when drag finishes

### DIFF
--- a/L.Map.Sync.js
+++ b/L.Map.Sync.js
@@ -125,6 +125,12 @@
                 });
             }, this);
 
+            originalMap.on('dragend', function(){
+                originalMap._syncMaps.forEach(function (toSync) {
+                    toSync.fire('moveend');
+                });
+            });
+
             originalMap.dragging._draggable._updatePosition = function () {
                 L.Draggable.prototype._updatePosition.call(this);
                 var self = this;
@@ -135,7 +141,7 @@
                             layer._google.setCenter(originalMap.getCenter());
                         }
                     });
-                    toSync.fire('moveend');
+                    toSync.fire('move');
                 });
             };
         }

--- a/L.Map.Sync.js
+++ b/L.Map.Sync.js
@@ -125,7 +125,7 @@
                 });
             }, this);
 
-            originalMap.on('dragend', function(){
+            originalMap.on('dragend', function () {
                 originalMap._syncMaps.forEach(function (toSync) {
                     toSync.fire('moveend');
                 });

--- a/test/spec.js
+++ b/test/spec.js
@@ -56,6 +56,55 @@ function makeMap (map, id, option) {
     return map;
 }
 
+var triggerDragAndDrop = function (selectorDrag, selectorDrop) {
+
+    // function for triggering mouse events
+    var fireMouseEvent = function (type, elem, centerX, centerY) {
+        var evt = document.createEvent('MouseEvents');
+        evt.initMouseEvent(type, true, true, window, 1, 1, 1, centerX, centerY, false, false, false, false, 0, elem);
+        elem.dispatchEvent(evt);
+    };
+
+    // fetch target elements
+    var elemDrag = document.querySelector(selectorDrag);
+    var elemDrop = document.querySelector(selectorDrop);
+    if (!elemDrag || !elemDrop) return false;
+
+    // calculate positions
+    var pos = elemDrag.getBoundingClientRect();
+    var center1X = Math.floor((pos.left + pos.right) / 2);
+    var center1Y = Math.floor((pos.top + pos.bottom) / 2);
+    pos = elemDrop.getBoundingClientRect();
+    var center2X = Math.floor((pos.left + pos.right) / 2);
+    var center2Y = Math.floor((pos.top + pos.bottom) / 2);
+
+    // mouse over dragged element and mousedown
+    fireMouseEvent('mousemove', elemDrag, center1X, center1Y);
+    fireMouseEvent('mouseenter', elemDrag, center1X, center1Y);
+    fireMouseEvent('mouseover', elemDrag, center1X, center1Y);
+    fireMouseEvent('mousedown', elemDrag, center1X, center1Y);
+
+    // start dragging process over to drop target
+    fireMouseEvent('dragstart', elemDrag, center1X, center1Y);
+    fireMouseEvent('drag', elemDrag, center1X, center1Y);
+    fireMouseEvent('mousemove', elemDrag, center1X, center1Y);
+    fireMouseEvent('drag', elemDrag, center2X, center2Y);
+    fireMouseEvent('mousemove', elemDrop, center2X, center2Y);
+
+    // trigger dragging process on top of drop target
+    fireMouseEvent('mouseenter', elemDrop, center2X, center2Y);
+    fireMouseEvent('dragenter', elemDrop, center2X, center2Y);
+    fireMouseEvent('mouseover', elemDrop, center2X, center2Y);
+    fireMouseEvent('dragover', elemDrop, center2X, center2Y);
+
+    // release dragged element on top of drop target
+    fireMouseEvent('drop', elemDrop, center2X, center2Y);
+    fireMouseEvent('dragend', elemDrag, center2X, center2Y);
+    fireMouseEvent('mouseup', elemDrag, center2X, center2Y);
+
+    return true;
+};
+
 describe('L.Sync', function () {
     this.timeout(5000);
 
@@ -115,6 +164,7 @@ describe('L.Sync', function () {
             it('still returns map instance', function () {
                 a.panBy([0, 2], NO_ANIMATE).should.equal(a);
             });
+
         });
 
         describe('_onResize', function () {
@@ -304,4 +354,40 @@ describe('L.Sync', function () {
         });
 
     });
+
+    describe('moveevents', function () {
+        beforeEach(function () {
+            beforeEach(function () {
+                a = makeMap(a, 'mapA');
+                b = makeMap(b, 'mapB');
+
+                a.sync(b);
+            });
+        });
+
+        it('moveend fired once on dragNdrop', function () {
+            var numberOfMoveend = 0;
+            b.on('moveend', function () {
+                numberOfMoveend++;
+            });
+
+            //simulate dragAndDrop
+            triggerDragAndDrop('#mapA', '#mapB');
+            numberOfMoveend.should.equal(1);
+        });
+
+        it('move fired once on _updatePosition', function () {
+            var numberOfMove = 0;
+            b.on('move', function () {
+                numberOfMove++;
+            });
+
+            triggerDragAndDrop('#mapA', '#mapB');
+            a.dragging._draggable._updatePosition();
+
+            numberOfMove.should.equal(1);
+        });
+    });
+
+
 });


### PR DESCRIPTION
This pull request is for issue #34.

This PR changes the following: When dragging the map, the 'move' event is called instead of 'moveend'. On dragend, the 'moveend' event is called on the synced maps.

These changes make it so the appropriate event is called. Before these changes 'moveend' was called on every single move. Therefore, not when the move ended like the event says. Here's a fiddle showing the issue: https://jsfiddle.net/Thuranel/zmp3qfqe/

Now, the 'moveend' event is only called at the end of dragging and the 'move' event is called while dragging the map. This keep the usual behavior while firing the appropriate events. Here's a fiddle showing the behavior with this PR: https://jsfiddle.net/Thuranel/gmjcom01/